### PR TITLE
feat(network): add Port Forwarding UI for User Mode networking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ qt_add_executable(QtEmu WIN32 MACOSX_BUNDLE
     src/machineconfig/machineconfigwindow.cpp src/machineconfig/machineconfigwindow.h
     src/machineconfig/createbridgedialog.cpp src/machineconfig/createbridgedialog.h
     src/machineconfig/networkadapterdialog.cpp src/machineconfig/networkadapterdialog.h
+    src/machineconfig/portforwarddialog.cpp src/machineconfig/portforwarddialog.h
     src/machineutils.cpp src/machineutils.h
     src/machinewizard.cpp src/machinewizard.h
     src/main.cpp

--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,7 @@ QtEmu_headers = [
                     'src/machinewizard.h',
                     'src/mainwindow.h',
                     'src/media.h',
+                    'src/networkadapter.h',
                     'src/qemu.h',
                     'src/components/customfilter.h',
                     'src/export-import/export.h',
@@ -43,7 +44,10 @@ QtEmu_headers = [
                     'src/machineconfig/machineconfighardwaretabs.h',
                     'src/machineconfig/machineconfigmedia.h',
                     'src/machineconfig/machineconfignetwork.h',
-                    'src/machineconfig/machineconfigwindow.h', 
+                    'src/machineconfig/machineconfigwindow.h',
+                    'src/machineconfig/createbridgedialog.h',
+                    'src/machineconfig/networkadapterdialog.h',
+                    'src/machineconfig/portforwarddialog.h',
                     'src/newmachine/acceleratorpage.h',
                     'src/newmachine/conclusionpage.h',
                     'src/newmachine/diskpage.h',
@@ -54,6 +58,7 @@ QtEmu_headers = [
                     'src/utils/cloudinitisoutils.h',
                     'src/utils/firstrunwizard.h',
                     'src/utils/logger.h',
+                    'src/utils/networkutils.h',
                     'src/utils/newdiskwizard.h',
                     'src/utils/systemutils.h'
                 ]
@@ -69,6 +74,7 @@ QtEmu_sources = [
                     'src/main.cpp',
                     'src/mainwindow.cpp',
                     'src/media.cpp',
+                    'src/networkadapter.cpp',
                     'src/qemu.cpp',
                     'src/components/customfilter.cpp',
                     'src/export-import/export.cpp',
@@ -92,6 +98,9 @@ QtEmu_sources = [
                     'src/machineconfig/machineconfigmedia.cpp',
                     'src/machineconfig/machineconfignetwork.cpp',
                     'src/machineconfig/machineconfigwindow.cpp',
+                    'src/machineconfig/createbridgedialog.cpp',
+                    'src/machineconfig/networkadapterdialog.cpp',
+                    'src/machineconfig/portforwarddialog.cpp',
                     'src/newmachine/acceleratorpage.cpp',
                     'src/newmachine/conclusionpage.cpp',
                     'src/newmachine/diskpage.cpp',
@@ -102,6 +111,7 @@ QtEmu_sources = [
                     'src/utils/cloudinitisoutils.cpp',
                     'src/utils/firstrunwizard.cpp',
                     'src/utils/logger.cpp',
+                    'src/utils/networkutils.cpp',
                     'src/utils/newdiskwizard.cpp',
                     'src/utils/systemutils.cpp'
                 ]

--- a/src/machineconfig/networkadapterdialog.h
+++ b/src/machineconfig/networkadapterdialog.h
@@ -11,7 +11,7 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QGroupBox>
-#include <QStackedWidget>
+#include <QTableWidget>
 #include "../networkadapter.h"
 
 class NetworkAdapterDialog : public QDialog
@@ -30,14 +30,21 @@ private slots:
     void onBackendChanged(int index);
     void onGenerateMacClicked();
     void onAutoMacClicked();
+    void onAddPortForwardClicked();
+    void onEditPortForwardClicked();
+    void onRemovePortForwardClicked();
+    void onPortForwardSelectionChanged();
 
 private:
     void setupUI();
     void loadFromAdapter();
     void updateBackendOptions();
+    void updatePortForwardTable();
+    QString formatPortForward(const PortForward &pf);
 
     NetworkAdapter *m_adapter;
     bool m_enableFields;
+    QList<PortForward> m_portForwards;
 
     QLineEdit *m_idEdit;
     QComboBox *m_backendCombo;
@@ -46,6 +53,12 @@ private:
     QPushButton *m_generateMacBtn;
     QCheckBox *m_autoMacCheck;
     QCheckBox *m_bootRomCheck;
+
+    QGroupBox *m_userGroup;
+    QTableWidget *m_portForwardTable;
+    QPushButton *m_addPortForwardBtn;
+    QPushButton *m_editPortForwardBtn;
+    QPushButton *m_removePortForwardBtn;
 
     QGroupBox *m_bridgeGroup;
     QComboBox *m_bridgeCombo;

--- a/src/machineconfig/portforwarddialog.cpp
+++ b/src/machineconfig/portforwarddialog.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Mateusz Krawczuk <mateusz.krawczuk@cybrixsystems.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "portforwarddialog.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QFormLayout>
+#include <QDialogButtonBox>
+#include <QRegularExpressionValidator>
+#include <QLabel>
+#include <QPushButton>
+
+PortForwardDialog::PortForwardDialog(QWidget *parent)
+    : QDialog(parent)
+{
+    setupUI();
+}
+
+PortForwardDialog::PortForwardDialog(const PortForward &forward, QWidget *parent)
+    : QDialog(parent)
+{
+    setupUI();
+    
+    int protocolIndex = m_protocolCombo->findText(forward.protocol);
+    if (protocolIndex >= 0) {
+        m_protocolCombo->setCurrentIndex(protocolIndex);
+    }
+    m_hostPortSpin->setValue(forward.hostPort);
+    m_guestPortSpin->setValue(forward.guestPort);
+    m_hostAddressEdit->setText(forward.hostAddress);
+    m_guestAddressEdit->setText(forward.guestAddress);
+}
+
+PortForwardDialog::~PortForwardDialog()
+{
+}
+
+void PortForwardDialog::setupUI()
+{
+    setWindowTitle(tr("Port Forwarding Rule"));
+    setMinimumWidth(350);
+
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    QFormLayout *formLayout = new QFormLayout();
+
+    m_protocolCombo = new QComboBox(this);
+    m_protocolCombo->addItem(QStringLiteral("tcp"));
+    m_protocolCombo->addItem(QStringLiteral("udp"));
+    formLayout->addRow(tr("Protocol:"), m_protocolCombo);
+
+    m_hostAddressEdit = new QLineEdit(this);
+    m_hostAddressEdit->setPlaceholderText(tr("Leave empty for all interfaces"));
+    formLayout->addRow(tr("Host Address:"), m_hostAddressEdit);
+
+    m_hostPortSpin = new QSpinBox(this);
+    m_hostPortSpin->setRange(1, 65535);
+    m_hostPortSpin->setValue(2222);
+    formLayout->addRow(tr("Host Port:"), m_hostPortSpin);
+
+    m_guestAddressEdit = new QLineEdit(this);
+    m_guestAddressEdit->setPlaceholderText(tr("Leave empty for guest default"));
+    formLayout->addRow(tr("Guest Address:"), m_guestAddressEdit);
+
+    m_guestPortSpin = new QSpinBox(this);
+    m_guestPortSpin->setRange(1, 65535);
+    m_guestPortSpin->setValue(22);
+    formLayout->addRow(tr("Guest Port:"), m_guestPortSpin);
+
+    mainLayout->addLayout(formLayout);
+
+    QLabel *infoLabel = new QLabel(this);
+    infoLabel->setText(tr("<small>Example: Host port 2222 → Guest port 22 allows SSH access<br>"
+                         "via <tt>ssh -p 2222 user@localhost</tt></small>"));
+    infoLabel->setStyleSheet(QStringLiteral("color: gray;"));
+    mainLayout->addWidget(infoLabel);
+
+    QDialogButtonBox *buttonBox = new QDialogButtonBox(
+        QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    m_okBtn = buttonBox->button(QDialogButtonBox::Ok);
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    mainLayout->addWidget(buttonBox);
+
+    connect(m_hostPortSpin, QOverload<int>::of(&QSpinBox::valueChanged), this, &PortForwardDialog::validate);
+    connect(m_guestPortSpin, QOverload<int>::of(&QSpinBox::valueChanged), this, &PortForwardDialog::validate);
+}
+
+void PortForwardDialog::validate()
+{
+    m_okBtn->setEnabled(m_hostPortSpin->value() > 0 && m_guestPortSpin->value() > 0);
+}
+
+PortForward PortForwardDialog::getPortForward() const
+{
+    PortForward forward;
+    forward.protocol = m_protocolCombo->currentText();
+    forward.hostPort = m_hostPortSpin->value();
+    forward.guestPort = m_guestPortSpin->value();
+    forward.hostAddress = m_hostAddressEdit->text().trimmed();
+    forward.guestAddress = m_guestAddressEdit->text().trimmed();
+    return forward;
+}

--- a/src/machineconfig/portforwarddialog.h
+++ b/src/machineconfig/portforwarddialog.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Mateusz Krawczuk <mateusz.krawczuk@cybrixsystems.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef PORTFORWARDDIALOG_H
+#define PORTFORWARDDIALOG_H
+
+#include <QDialog>
+#include <QComboBox>
+#include <QSpinBox>
+#include <QLineEdit>
+#include "../networkadapter.h"
+
+class PortForwardDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit PortForwardDialog(QWidget *parent = nullptr);
+    explicit PortForwardDialog(const PortForward &forward, QWidget *parent = nullptr);
+    ~PortForwardDialog();
+
+    PortForward getPortForward() const;
+
+private slots:
+    void validate();
+
+private:
+    void setupUI();
+
+    QComboBox *m_protocolCombo;
+    QSpinBox *m_hostPortSpin;
+    QSpinBox *m_guestPortSpin;
+    QLineEdit *m_hostAddressEdit;
+    QLineEdit *m_guestAddressEdit;
+    QPushButton *m_okBtn;
+};
+
+#endif

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -11,6 +11,7 @@ incdir_tests = include_directories('../src')
 test_cloudinitisoutils_headers = [
     '../src/utils/cloudinitisoutils.h',
     '../src/machine.h',
+    '../src/networkadapter.h',
     '../src/boot.h',
     '../src/media.h',
     '../src/qemu.h',
@@ -22,6 +23,7 @@ test_cloudinitisoutils_sources = [
     'test_cloudinitisoutils.cpp',
     '../src/utils/cloudinitisoutils.cpp',
     '../src/machine.cpp',
+    '../src/networkadapter.cpp',
     '../src/boot.cpp',
     '../src/media.cpp',
     '../src/qemu.cpp',
@@ -49,6 +51,7 @@ test('test_cloudinitisoutils', test_cloudinitisoutils_exe, timeout: 30)
 test_machine_cloudinit_headers = [
     '../src/machine.h',
     '../src/machineutils.h',
+    '../src/networkadapter.h',
     '../src/boot.h',
     '../src/media.h',
     '../src/qemu.h',
@@ -61,6 +64,7 @@ test_machine_cloudinit_sources = [
     'test_machine_cloudinit.cpp',
     '../src/machine.cpp',
     '../src/machineutils.cpp',
+    '../src/networkadapter.cpp',
     '../src/boot.cpp',
     '../src/media.cpp',
     '../src/qemu.cpp',
@@ -89,6 +93,7 @@ test('test_machine_cloudinit', test_machine_cloudinit_exe, timeout: 30)
 test_machine_customargs_headers = [
     '../src/machine.h',
     '../src/machineutils.h',
+    '../src/networkadapter.h',
     '../src/boot.h',
     '../src/media.h',
     '../src/qemu.h',
@@ -101,6 +106,7 @@ test_machine_customargs_sources = [
     'test_machine_customargs.cpp',
     '../src/machine.cpp',
     '../src/machineutils.cpp',
+    '../src/networkadapter.cpp',
     '../src/boot.cpp',
     '../src/media.cpp',
     '../src/qemu.cpp',


### PR DESCRIPTION
## Summary
- Add PortForwardDialog for configuring port forwarding rules
- Add table display of port forwarding rules in NetworkAdapterDialog
- Support TCP/UDP protocols with host/guest address and port configuration
- Users can add, edit, and remove port forwarding rules

## New Files
- `src/machineconfig/portforwarddialog.h/cpp` - Port forwarding configuration dialog

## Test Plan
- [x] All existing unit tests pass
- [x] Build succeeds on Linux
- [ ] Manual testing with QEMU VMs
- [ ] Test port forwarding (e.g., SSH via host:2222 -> guest:22)

## Depends On
- #31 (Network bridge support - Phase 1)